### PR TITLE
bugfix/security-update-automerge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,6 @@ updates:
       timezone: Asia/Kolkata
     open-pull-requests-limit: 5
     target-branch: develop
-    reviewers:
-      - libinvarghese
     assignees:
       - libinvarghese
     allow:
@@ -33,8 +31,6 @@ updates:
       timezone: Asia/Kolkata
     open-pull-requests-limit: 5
     target-branch: develop
-    reviewers:
-      - libinvarghese
     assignees:
       - libinvarghese
     allow:
@@ -51,8 +47,6 @@ updates:
       timezone: Asia/Kolkata
     open-pull-requests-limit: 5
     target-branch: develop
-    reviewers:
-      - libinvarghese
     assignees:
       - libinvarghese
     commit-message:

--- a/.github/jsTemplates/dependabot.yml.ts
+++ b/.github/jsTemplates/dependabot.yml.ts
@@ -10,7 +10,7 @@ const packageSettings = {
   },
   'open-pull-requests-limit': 5,
   'target-branch': 'develop',
-  reviewers: ['libinvarghese'],
+  // reviewers: ['libinvarghese'],
   assignees: ['libinvarghese'],
   allow: [
     {

--- a/.github/jsTemplates/workflows/automerge.yml.ts
+++ b/.github/jsTemplates/workflows/automerge.yml.ts
@@ -1,4 +1,4 @@
-import { protectedBranches, defaultJobMachine } from './constants';
+import { defaultJobMachine } from './constants';
 import * as STEP from './steps';
 
 const bot = 'dependabot[bot]';
@@ -9,7 +9,7 @@ export = {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     pull_request: {
       types: ['edited', 'labeled', 'opened', 'ready_for_review', 'reopened', 'synchronize', 'unlabeled', 'unlocked'],
-      branches: protectedBranches,
+      branches: ['develop'],
     },
   },
   jobs: {

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -20,7 +20,6 @@ name: automerge-dependabot
       - unlocked
     branches:
       - develop
-      - master
 jobs:
   pre-automerge:
     outputs:


### PR DESCRIPTION
ci: fix: github security updates are merged into master
ci(dependabot): remove reviewer for dependabot pull-requests